### PR TITLE
feat: support require es module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.5",
   "description": "TiDB Serverless driver",
   "main": "dist/index.js",
+  "module": "./dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist"
@@ -10,11 +11,16 @@
   "engines": {
     "node": ">=16"
   },
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/cjs/index.js"
+  },
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist/",
     "prebuild": "npm run clean",
-    "build": "tsc",
+    "build": "tsc && tsc --module commonjs --outDir dist/cjs",
+    "postbuild": "echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "lint": "eslint src/",
     "pretest": "npm run build",
     "test": "jest __tests__ --passWithNoTests",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tidbcloud/serverless",
   "version": "0.0.5",
   "description": "TiDB Serverless driver",
-  "main": "dist/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
TypeScript compiles the `import` statement into a `require` statement.

```
Object.defineProperty(exports, "__esModule", { value: true });
const serverless_1 = require("@tidbcloud/serverless");
```

When the user runs the program, you will encounter the following errors:

```
var serverless_1 = require("@tidbcloud/serverless");
                   ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/bohnen/Work/ts-drizzle-serverless/node_modules/@tidbcloud/serverless/dist/index.js from /Users/bohnen/Work/ts-drizzle-serverless/serverless.js not supported.
Instead change the require of index.js in /Users/bohnen/Work/ts-drizzle-serverless/serverless.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/Users/bohnen/Work/ts-drizzle-serverless/serverless.js:39:20) {
  code: 'ERR_REQUIRE_ESM'
}
```